### PR TITLE
L1MusicSync in HA

### DIFF
--- a/discovery-sonoff_l1.yaml
+++ b/discovery-sonoff_l1.yaml
@@ -27,7 +27,7 @@ variables:
   mac_address: !input "mac_address"
   macaddr: '{{- mac_address.split(":") | join -}}'
   payload_musicsync: '{{ ''{"name":"'' ~ name ~ '' Music Sync","state_topic":"''
-    ~ topic ~ ''/musicsync","state_on":"1","state_off":"0","payload_on":"1","payload_off":"0","command_topic":"cmnd/'' ~ topic ~ ''/var1","availability_topic":"tele/''
+    ~ topic ~ ''/musicsync","state_on":"ON","state_off":"OFF","payload_on":"1","payload_off":"0","command_topic":"cmnd/'' ~ topic ~ ''/var1","availability_topic":"tele/''
     ~ topic ~''/LWT","icon":"mdi:music","payload_available":"Online","payload_not_available":"Offline","unique_id":"''
     ~ macaddr ~ ''_musicsync","device":{"cns":[["mac","'' ~ macaddr ~ ''"]]}}''
     }}'

--- a/discovery-sonoff_l1.yaml
+++ b/discovery-sonoff_l1.yaml
@@ -1,0 +1,77 @@
+blueprint:
+  name: "Tasmota Discovery: Sonoff L1 Music Mode"
+  description: "Set up music mode on a Sonoff L1 with\
+    \ sensor and selected sensitivity and speed.\n\nRequires some rules configured in Tasmota.\
+    \ See your device template page for rules:\n\n  - [Sonoff L1 LED Strip](https://templates.blakadder.com/sonoff_L1.html)\n"
+  domain: automation
+  input:
+    name:
+      name: Device name
+      description: Name of the device to be used in sensor name creation.
+      selector:
+        text: {}
+    topic:
+      name: Tasmota MQTT Topic
+      description: Found in Information tab of the webUI.
+      selector:
+        text: {}
+    mac_address:
+      name: Tasmota MAC Address
+      description: Found in Information tab of the webUI.
+  source_url: https://github.com/mihsu81/blueprints/blob/main/discovery-sonoff_l1.yaml
+mode: single
+max_exceeded: silent
+variables:
+  topic: !input "topic"
+  name: !input "name"
+  mac_address: !input "mac_address"
+  macaddr: '{{- mac_address.split(":") | join -}}'
+  payload_musicsync: '{{ ''{"name":"'' ~ name ~ '' Music Sync","state_topic":"''
+    ~ topic ~ ''/musicsync","state_on":"1","state_off":"0","payload_on":"1","payload_off":"0","command_topic":"cmnd/'' ~ topic ~ ''/var1","availability_topic":"tele/''
+    ~ topic ~''/LWT","icon":"mdi:music","payload_available":"Online","payload_not_available":"Offline","unique_id":"''
+    ~ macaddr ~ ''_musicsync","device":{"cns":[["mac","'' ~ macaddr ~ ''"]]}}''
+    }}'
+  payload_sensitive:
+    '{{ ''{"name":"'' ~ name ~ '' Music Sensitivity","state_topic":"''
+    ~ topic ~ ''/sensitive","command_topic":"cmnd/'' ~ topic ~ ''/var2","availability_topic":"tele/''
+    ~ topic ~''/LWT","min":1,"max":10,"icon":"mdi:surround-sound","payload_available":"Online","payload_not_available":"Offline","unique_id":"''
+    ~ macaddr ~ ''_sensitive","device":{"cns":[["mac","'' ~ macaddr ~ ''"]]}}''
+    }}'
+  payload_speed: '{{ ''{"name":"'' ~ name ~ '' Music Speed","state_topic":"''
+    ~ topic ~ ''/speed","command_topic":"cmnd/'' ~ topic ~ ''/var3","availability_topic":"tele/''
+    ~ topic ~''/LWT","min":1,"max":100,"icon":"mdi:speedometer-medium","payload_available":"Online","payload_not_available":"Offline","unique_id":"''
+    ~ macaddr ~ ''_speed","device":{"cns":[["mac","'' ~ macaddr ~ ''"]]}}''
+    }}'
+trigger_variables:
+  topic: !input "topic"
+trigger:
+  - platform: homeassistant
+    event: start
+  - platform: mqtt
+    topic: '{{ "tele/" ~ topic ~ "/LWT" }}'
+    payload: Online
+action:
+  - service: mqtt.publish
+    data:
+      topic: homeassistant/switch/{{ macaddr }}/musicsync/config
+      retain: true
+      payload: "{{ payload_musicsync }}"
+  - service: mqtt.publish
+    data:
+      topic: homeassistant/number/{{ macaddr }}/sensitive/config
+      retain: true
+      payload: "{{ payload_sensitive }}"
+  - service: mqtt.publish
+    data:
+      topic: homeassistant/number/{{ macaddr }}/speed/config
+      retain: true
+      payload: "{{ payload_speed }}"
+  - delay:
+      hours: 0
+      minutes: 0
+      seconds: 5
+      milliseconds: 0
+  - service: mqtt.publish
+    data:
+      topic: cmnd/{{ topic }}/l1musicsync
+      payload: ""


### PR DESCRIPTION
Rules to be added on the device:

Rule2 on var1#State do Backlog L1MusicSync %value%,x,x; Event checkvar=%var1% endon on Event#checkvar=1 do Publish %topic%/musicsync ON endon on Event#checkvar=0 do Publish %topic%/musicsync OFF endon on var2#State do L1MusicSync 1,%value%,x endon on var2#state do Backlog L1MusicSync; Publish %topic%/sensitive %value% endon on var3#State do L1MusicSync 1,x,%value% endon on var3#State do Backlog L1MusicSync; Publish %topic%/speed %value% endon

Rule2 1

Backlog Rule3 on L1MusicSync#Mode do Publish %topic%/musicsync %value% endon on L1MusicSync#Sensitive do Publish %topic%/sensitive %value% endon on L1MusicSync#Speed do Publish %topic%/speed %value% endon; Rule3 1

I didn't find a way to use multiple Backlog for Rule2 to also enable it. :)