### PR TITLE
fix active unit of measurement not valid for payload_filterlife

### DIFF
--- a/discovery_blitzhome_bh-ap1.yaml
+++ b/discovery_blitzhome_bh-ap1.yaml
@@ -100,7 +100,6 @@ variables:
       '{
         "name":"' ~ name ~ ' Filter Life",
         "state_topic":"' ~ topic ~ '/filterlife",
-        "device_class":"pm25",
         "icon":"mdi:ticket-percent-outline",
         "unit_of_measurement":"%",
         "entity_category":"diagnostic",


### PR DESCRIPTION
Home-Assistant showing the following log entry:

WARNING (MainThread) [homeassistant.components.sensor] Entity sensor.blitzhome_air_purifier_filter_life (<class 'homeassistant.components.mqtt.sensor.MqttSensor'>) is using native unit of measurement '%' which is not a valid unit for the device class ('pm25') it is using; expected one of ['µg/m³']; Please update your configuration if your entity is manually configured, otherwise create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue+label%3A%22integration%3A+mqtt%22

removing the device class entry solves this.